### PR TITLE
Testing navigate vs window.replace

### DIFF
--- a/chatapp/src/utils/EditChat.jsx
+++ b/chatapp/src/utils/EditChat.jsx
@@ -117,7 +117,7 @@ const EditChat = ({ userList, roomOwner, roomID, roomName, displayName }) => {
   const deleteChatRoom = async () => {
     try {
       await deleteDoc(chatRoomRef);
-      window.location.replace("/home");
+      navigate("/home");
     } catch (error) {
       console.error("Error deleting chat: ", error);
     }


### PR DESCRIPTION
- On deployed site, window.replace does not work to redirect user once chat is deleted
- Hoping navigate plays nicer w/ deployed version so no longer get 404 error once deleted