### PR TITLE
Bug fixes - Google Auth

### DIFF
--- a/chatapp/public/index.html
+++ b/chatapp/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Live messaging application created using Firestore."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/chatapp/src/components/Landing.jsx
+++ b/chatapp/src/components/Landing.jsx
@@ -10,6 +10,8 @@ import {
   serverTimestamp,
   doc,
   setDoc,
+  updateDoc,
+  getDoc,
   query,
   where,
   getDocs,
@@ -53,7 +55,13 @@ const Landing = () => {
 
       if (!emailQuerySnapshot.empty) {
         // Email already exists
-        console.log("Email already exists.");
+        let userDocRef = null;
+        console.log("Email already exists. Updating provider", emailQuerySnapshot);
+        await emailQuerySnapshot.forEach((doc) => {
+          userDocRef = doc.ref;
+        })
+        // const updateUserRef = doc(collection(db, "chat-users"), where("email", "==", email));
+        updateDoc(userDocRef, {provider: "google", username: username})
       }
 
       if (usernameQuerySnapshot.empty && emailQuerySnapshot.empty) {
@@ -62,6 +70,7 @@ const Landing = () => {
         await setDoc(userDocRef, {
           username: username,
           email: email,
+          provider: "google",
           timestamp: serverTimestamp(),
         });
         console.log("User document created.");

--- a/chatapp/src/components/Register.jsx
+++ b/chatapp/src/components/Register.jsx
@@ -45,7 +45,7 @@ const Login = () => {
     // Check for duplicate username
     const duplicateUsernameQuery = query(
       userCollectionRef,
-      where("username", "==", username)
+      where("username", "==", username, "&&", "provider", "==", "email")
     );
     const usernameQuerySnapshot = await getDocs(duplicateUsernameQuery);
 
@@ -63,6 +63,7 @@ const Login = () => {
 
     if (!emailQuerySnapshot.empty) {
       setErrorMessage("Email is already registered.");
+      console.log(emailQuerySnapshot)
       return;
     }
 
@@ -88,6 +89,7 @@ const Login = () => {
         await setDoc(userDocRef, {
           username: username,
           email: email,
+          provider: "email",
           timestamp: serverTimestamp(),
         });
         console.log("User document created.");


### PR DESCRIPTION
- When a user signs up with GMAIL account manually, then tries signing in through Google Auth after, it was overriding the account provider. User loses chat history and is unable to log back in manually.
- Fixed by switching Firebase setting to create multiple accounts for each identity provider, so now a google provider sign in does not have an email identifier, allowing for two accounts to be created based on sign in method
-Also added some manual auth checks just in case bug persists, if account is overriden a special error message will appear telling user to sign in with Google instead. Chat user profiles now have a 'provider' type value upon creation (either google or email type)